### PR TITLE
Build with GHC 7.4

### DIFF
--- a/hxt-regex-xmlschema/hxt-regex-xmlschema.cabal
+++ b/hxt-regex-xmlschema/hxt-regex-xmlschema.cabal
@@ -47,6 +47,5 @@ Library
   ghc-prof-options: -auto-all -caf-all
 
   build-depends:     base               >= 4   && < 5,
-                     haskell98          >= 1   && < 2,
                      parsec             >= 2.1 && < 4,
                      hxt-charproperties >= 9   && < 10

--- a/hxt/hxt.cabal
+++ b/hxt/hxt.cabal
@@ -166,7 +166,6 @@ library
  extensions: MultiParamTypeClasses DeriveDataTypeable FunctionalDependencies FlexibleInstances
 
  build-depends: base       >= 4   && < 5,
-                haskell98  >= 1   && < 2,
                 containers >= 0.2 && < 1,
                 directory  >= 1   && < 2,
                 filepath   >= 1   && < 2,


### PR DESCRIPTION
I've done the minimum work needed to make the 'hxt' package build with GHC 7.4 RC 1. Some of the ancillary modules may need additional work - let me know if that will hold up this patch.
