### PR TITLE
Port to tagsoup 0.13.

### DIFF
--- a/hxt-tagsoup/hxt-tagsoup.cabal
+++ b/hxt-tagsoup/hxt-tagsoup.cabal
@@ -33,7 +33,7 @@ library
  extensions: MultiParamTypeClasses DeriveDataTypeable FunctionalDependencies FlexibleInstances
 
  build-depends: base               >= 4    && < 5,
-                tagsoup            >= 0.10 && < 0.13,
+                tagsoup            >= 0.13 && < 0.14,
                 hxt-charproperties >= 9    && < 10,
                 hxt-unicode        >= 9    && < 10,
                 hxt                >= 9.1  && < 10

--- a/hxt-tagsoup/src/Text/XML/HXT/Parser/TagSoup.hs
+++ b/hxt-tagsoup/src/Text/XML/HXT/Parser/TagSoup.hs
@@ -244,7 +244,7 @@ extendNsEnv withNamespaces al1 env
 lookupEntity    :: Bool -> Bool -> (String, Bool) -> Tags
 lookupEntity withWarnings _asHtml (e0@('#':e), withSemicolon)
     = case lookupNumericEntity e of
-      Just c  -> (TagText [c])
+      Just c  -> (TagText c)
 		 : missingSemi
       Nothing -> ( TagText $ "&" ++ e0 ++ [';' | withSemicolon])
 		 : if withWarnings


### PR DESCRIPTION
tagsoup 0.13 changed lookupNumericEntity to return a String rather than a Char.  This updates hxt-tagsoup to work with that.
