### PR TITLE
correcting the hxt-tagsoup usage example

### DIFF
--- a/hxt-tagsoup/src/Text/XML/HXT/Arrow/TagSoupInterface.hs
+++ b/hxt-tagsoup/src/Text/XML/HXT/Arrow/TagSoupInterface.hs
@@ -44,7 +44,7 @@ Here is an example, how to use it:
 > import Text.HXT.XML.TagSoup
 > ...
 >
-> readDocument [ withExpat ] "some-file.xml"
+> readDocument [ withTagSoup ] "some-file.xml"
 > ...
 
 reads the given document and parses it with the lazy tagsoup parser.


### PR DESCRIPTION
Changed the hxt-tagsoup usage example to use withTagSoup instead of withExpat
