### PR TITLE
Allow older version of mtl for Haskell Platform compatibility

### DIFF
--- a/hxt/hxt.cabal
+++ b/hxt/hxt.cabal
@@ -202,7 +202,7 @@ library
                 filepath   >= 1     && < 2,
                 parsec     >= 2.1   && < 4,
                 HUnit      >= 1.2   && < 2,
-                mtl        >= 2.2.1 && < 3,
+                mtl        >= 2.0.1 && < 3,
                 deepseq    >= 1.1   && < 2,
                 bytestring >= 0.9   && < 1,
                 binary     >= 0.5   && < 1,

--- a/hxt/src/Text/XML/HXT/Arrow/Pickle/Xml.hs
+++ b/hxt/src/Text/XML/HXT/Arrow/Pickle/Xml.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
 
@@ -53,7 +54,11 @@ import           Control.Applicative              (Applicative (..))
 import           Control.Arrow.ArrowList
 import           Control.Arrow.ListArrows
 import           Control.Monad                    ()
+#if MIN_VERSION_mtl(2,2,0)
 import           Control.Monad.Except             (MonadError (..))
+#else
+import           Control.Monad.Error              (MonadError (..))
+#endif
 import           Control.Monad.State              (MonadState (..), gets,
                                                    modify)
 


### PR DESCRIPTION
Since `mtl-2.1.3` is bundled with the Haskell Platform, HP users can't (easily) install `hxt` at the moment. I reduced the lower version bound of `mtl` and used `cabal` macros where needed to ensure that deprecation errors related to `Control.Monad.Error` aren't generated if a recent version of `mtl` is being used.
