### PR TITLE
hxt-regex-xmlschema: Allow Cabal-version >= 1.10

### DIFF
--- a/hxt-regex-xmlschema/hxt-regex-xmlschema.cabal
+++ b/hxt-regex-xmlschema/hxt-regex-xmlschema.cabal
@@ -24,7 +24,7 @@ Stability:           stable
 Category:            Text
 Homepage:            http://www.haskell.org/haskellwiki/Regular_expressions_for_XML_Schema
 Build-type:          Simple
-Cabal-version:       >=1.18
+Cabal-version:       >=1.10
 
 extra-source-files:
   examples/colorizeProgs/ColorizeSourceCode.hs


### PR DESCRIPTION
Is there a reason the lower bound is `>= 1.18`? 1.10 seems to be compatible (no warnings). 1.18 is causing build problems on travis, see e.g. https://travis-ci.org/silkapp/generic-xmlpickler/builds/52638486

I don't know why the problem occurs, cabal-1.18 is installed there... but perhaps the easiest fix is to merge this.

Cheers

