### PR TITLE
Fix a few small typos in documentation comments

### DIFF
--- a/hxt-curl/src/Text/XML/HXT/IO/GetHTTPLibCurl.hs
+++ b/hxt-curl/src/Text/XML/HXT/IO/GetHTTPLibCurl.hs
@@ -93,7 +93,7 @@ releaseCurl     = putMVar curlResource ()
 -- via the curl binding
 -- <http://hackage.haskell.org/cgi-bin/hackage-scripts/package/curl>
 -- This function tries to support mostly all curl options concerning HTTP requests.
--- The naming convetion is as follows: A curl option must be prefixed by the string
+-- The naming convention is as follows: A curl option must be prefixed by the string
 -- \"curl\" and then written exactly as described in the curl man page
 -- (<http://curl.haxx.se/docs/manpage.html>).
 --

--- a/hxt/src/Text/XML/HXT/Arrow/DocumentInput.hs
+++ b/hxt/src/Text/XML/HXT/Arrow/DocumentInput.hs
@@ -231,7 +231,7 @@ setBaseURIFromDoc
    If the source name is empty, the input is read from standard input.
 
    The source is transformed into an absolute URI. If the source is a relative URI, or a file name,
-   it is expanded into an absolut URI with respect to the current base URI.
+   it is expanded into an absolute URI with respect to the current base URI.
    The default base URI is of protocol \"file\" and points to the current working directory.
 
    The currently supported protocols are \"http\", \"file\", \"stdin\" and \"string\".

--- a/hxt/src/Text/XML/HXT/Arrow/XmlOptions.hs
+++ b/hxt/src/Text/XML/HXT/Arrow/XmlOptions.hs
@@ -241,7 +241,7 @@ a_verbose                       = "verbose"
 -- ------------------------------------------------------------
 
 -- |
--- select options from a predefined list of option desciptions
+-- select options from a predefined list of option descriptions
 
 selectOptions   :: [String] -> [OptDescr a] -> [OptDescr a]
 selectOptions ol os

--- a/hxt/src/Text/XML/HXT/Arrow/XmlState/SystemConfig.hs
+++ b/hxt/src/Text/XML/HXT/Arrow/XmlState/SystemConfig.hs
@@ -31,12 +31,12 @@ import Text.XML.HXT.Arrow.XmlState.TypeDefs
 
 -- config options
 
--- | @withTace level@ : system option, set the trace level, (0..4)
+-- | @withTrace level@ : system option, set the trace level, (0..4)
 
 withTrace                       :: Int -> SysConfig
 withTrace                       = setS theTraceLevel
 
--- | @withSysAttr key value@ : store an arbitarty key value pair in system state
+-- | @withSysAttr key value@ : store an arbitrary key value pair in system state
 
 withSysAttr                     :: String -> String -> SysConfig
 withSysAttr n v                 = chgS theAttrList (addEntry n v)

--- a/hxt/src/Text/XML/HXT/DOM/TypeDefs.hs
+++ b/hxt/src/Text/XML/HXT/DOM/TypeDefs.hs
@@ -75,7 +75,7 @@ data XNode      = XText           String                        -- ^ ordinary te
                 | XCdata          String                        -- ^ CDATA section                                       (leaf)
                 | XPi             QName XmlTrees                -- ^ Processing Instr with qualified name                (leaf)
                                                                 --   with list of attributes.
-                                                                --   If tag name is xml, attributs are \"version\", \"encoding\", \"standalone\",
+                                                                --   If tag name is xml, attributes are \"version\", \"encoding\", \"standalone\",
                                                                 --   else attribute list is empty, content is a text child node
                 | XTag            QName XmlTrees                -- ^ tag with qualified name and list of attributes (inner node or leaf)
                 | XDTD            DTDElem  Attributes           -- ^ DTD element with assoc list for dtd element features


### PR DESCRIPTION
This branch fixes a few small typos I found.