### PR TITLE
hxt-tagsoup: Bump upper bound on tagsoup to < 0.15

### DIFF
--- a/hxt-tagsoup/hxt-tagsoup.cabal
+++ b/hxt-tagsoup/hxt-tagsoup.cabal
@@ -33,7 +33,7 @@ library
  extensions: MultiParamTypeClasses DeriveDataTypeable FunctionalDependencies FlexibleInstances CPP
 
  build-depends: base               >= 4    && < 5,
-                tagsoup            >= 0.13 && < 0.14,
+                tagsoup            >= 0.13 && < 0.15,
                 hxt-charproperties >= 9    && < 10,
                 hxt-unicode        >= 9    && < 10,
                 hxt                >= 9.1  && < 10


### PR DESCRIPTION
I've checked that cabal install works after this change.

Reason: stackage nightly has moved to tagsoup 0.14

Stackage issue: https://github.com/fpco/stackage/issues/1598#issuecomment-231594894