### PR TITLE
Make `hxt-cache` buildable on Windows

### DIFF
--- a/hxt-cache/hxt-cache.cabal
+++ b/hxt-cache/hxt-cache.cabal
@@ -34,16 +34,16 @@ library
 
  default-language:  Haskell2010
 
- build-depends: base       >= 4   && < 5,
-                bytestring >= 0.9 && < 1,
-                binary     >= 0.5 && < 1,
-                containers >= 0.2 && < 1,
-                deepseq    >= 1.1 && < 2,
-                directory  >= 1.2 && < 2,
-                filepath   >= 1.1 && < 2,
-                hxt        >= 9   && < 10,
-                time       >= 1.4 && < 2,
-                unix       >= 2.3 && < 3,
+ build-depends: base        >= 4   && < 5,
+                bytestring  >= 0.9 && < 1,
+                binary      >= 0.5 && < 1,
+                containers  >= 0.2 && < 1,
+                deepseq     >= 1.1 && < 2,
+                directory   >= 1.2 && < 2,
+                filepath    >= 1.1 && < 2,
+                hxt         >= 9   && < 10,
+                time        >= 1.4 && < 2,
+                unix-compat >= 0.3 && < 0.5,
                 SHA        >= 1.4 && < 2
  if impl(ghc < 7.10)
    build-depends: old-locale >= 1 && < 2,

--- a/hxt-cache/src/Text/XML/HXT/Arrow/XmlCache.hs
+++ b/hxt-cache/src/Text/XML/HXT/Arrow/XmlCache.hs
@@ -59,7 +59,7 @@ import           System.Locale                        (defaultTimeLocale,
                                                        rfc822DateFormat)
 #endif
 import           System.IO.Unsafe                     (unsafePerformIO)
-import           System.Posix                         (touchFile)
+import           System.PosixCompat.Files             (touchFile)
 
 import           Text.XML.HXT.Arrow.Binary
 import           Text.XML.HXT.Arrow.XmlState.TypeDefs


### PR DESCRIPTION
This replaces the `unix` dependency with `unix-compat` which builds on
Windows.

@UweSchmidt I occasionally build `hunt` on Windows and this blocks the build using `cabal new-build` as it solves for all targets (see https://github.com/haskell/cabal/issues/3978).
