### PR TITLE
Use post-composition instead of lifting to arrow

### DIFF
--- a/hxt/src/Control/Arrow/ArrowState.hs
+++ b/hxt/src/Control/Arrow/ArrowState.hs
@@ -68,8 +68,8 @@ class Arrow a => ArrowState s a | a -> s where
     --
     -- > newId :: SLA Int b String
     -- > newId = nextState (+1)
-    -- >         >>>
-    -- >         arr (('#':) . show)
+    -- >         >>^
+    -- >         ('#':) . show
     -- >
     -- > runSLA 0 (newId <+> newId <+> newId) undefined
     -- >   = ["#1", "#2", "#3"]


### PR DESCRIPTION
Since following holds, I think it's preferable to get rid of parenthesis and use more convenient post-composition with a pure function;

```haskell
a1 >>^ f = a1 >>> arr f
```