### PR TITLE
Correct typos and grammar in introduction

### DIFF
--- a/hxt/src/Control/Arrow/ArrowList.hs
+++ b/hxt/src/Control/Arrow/ArrowList.hs
@@ -13,10 +13,10 @@
 
    This module defines the interface for list arrows.
 
-   A list arrow is a function, that gives a list of results
-   for a given argument. A single element result represents a normal function.
-   An empty list oven indicates, the function is undefined for the given argument.
-   The empty list may also represent False, none empty lists True.
+   A list arrow is a function that gives a list of results
+   for a given argument. A single-element result represents a normal function.
+   An empty list often indicates that the function is undefined for the given argument.
+   The empty list may also represent False; non-empty lists True.
    A list with more than one element gives all results for a nondeterministic function.
 
 -}


### PR DESCRIPTION
Please accept my apologies if this is too trivial a pull request, but I was today reading the documentation in this file, and I had to read the introduction a few times before I understood what it meant.

- There should be no comma in front of *that* (while there should be comma in front of *which*).
- It's *non-empty*, not *none empty*
- Regarding *single-element result*, that's a compound adjective, so here I've followed Strunk & White and added a hyphen.