### PR TITLE
Add MonadFail instance for Unpickler

### DIFF
--- a/hxt/src/Text/XML/HXT/Arrow/Pickle/Xml.hs
+++ b/hxt/src/Text/XML/HXT/Arrow/Pickle/Xml.hs
@@ -59,6 +59,10 @@ import           Control.Arrow.ArrowList
 import           Control.Arrow.ListArrows
 import           Control.Monad                    ()
 
+#if !MIN_VERSION_base(4,13,0)
+import           Control.Monad.Fail
+#endif
+
 #if MIN_VERSION_mtl(2,2,0)
 import           Control.Monad.Except             (MonadError (..))
 #else
@@ -157,6 +161,11 @@ instance MonadError UnpickleErr Unpickler where
                   case r of
                     Left err -> runUP (handler err) st  -- not st', state will be reset in error case
                     _        -> (r, st')
+
+#if MIN_VERSION_base(4,9,0)
+instance MonadFail Unpickler where 
+    fail = throwMsg
+#endif
 
 throwMsg        :: String -> Unpickler a
 throwMsg msg    = UP $ \ st -> (Left (msg, st), st)


### PR DESCRIPTION
This PR adds a `MonadFail` instance for the `Unpickler` type which is required in recent versions of GHC/`base` for `fail` to be usable. The lack of the instance breaks (to my knowledge) at least one package (`hsaml2`). 