### PR TITLE
Don't canonicalize during parsing

### DIFF
--- a/hxt/src/Text/XML/HXT/Parser/XmlParsec.hs
+++ b/hxt/src/Text/XML/HXT/Parser/XmlParsec.hs
@@ -449,8 +449,7 @@ content
 
 content         :: XParser s XmlTrees
 content
-    = XT.mergeTextNodes <$>
-      many
+    = many
       ( ( do            -- parse markup but no closing tags
           try ( XT.lt
                 >>


### PR DESCRIPTION
My use case is editing documents written by humans, so I want to preserve the structure of the document as much as possible. Using `withCanonicalize no` CDATA sections should be preserved, however currently that is only the case if they are the only child of a node, as otherwise `mergeTextNodes` will delete them. As far as I can tell the only thing `mergeTextNodes` does during parsing is convert CDATA sections and character references to normal text nodes. Both of these should only be done in canonicalization. A legitamite purpose `mergeTextNodes` might fullfill here would be merging two consecutive actual text nodes, but I don't think the parser will create such a situation in the first place.

If this was accepted this should probably also be changed for `htmlContent`.