### PR TITLE
Fix bug in parsing of \t and \r

### DIFF
--- a/hxt-regex-xmlschema/src/Text/Regex/XMLSchema/Generic/RegexParser.hs
+++ b/hxt-regex-xmlschema/src/Text/Regex/XMLSchema/Generic/RegexParser.hs
@@ -313,7 +313,7 @@ singleCharEsc'  :: Parser Char
 singleCharEsc'
     = do
       c <- satisfy (`elem` "nrt\\|.?*+(){}-[]^")
-      return $ maybe c id . lookup c . zip "ntr" $ "\n\r\t"
+      return $ maybe c id . lookup c . zip "nrt" $ "\n\r\t"
 
 multiCharEscExt    :: StringLike s => Parser (GenRegex s)
 multiCharEscExt


### PR DESCRIPTION
Simple typo (took me a long time to realise why a regex including `[...\r...]` was producing a GenRegex with `[&#9;...]` and not `[&#13;...]`).