### PR TITLE
Fix unicode support.

### DIFF
--- a/hxt/hxt.cabal
+++ b/hxt/hxt.cabal
@@ -252,3 +252,15 @@ library
 Source-Repository head
   Type:     git
   Location: git://github.com/UweSchmidt/hxt.git
+
+
+test-suite spec
+  type:               exitcode-stdio-1.0
+  main-is:            ReadBinary.hs
+  hs-source-dirs:     test
+
+  build-depends:
+                base
+              , hxt
+              , bytestring
+              , utf8-string

--- a/hxt/hxt.cabal
+++ b/hxt/hxt.cabal
@@ -236,6 +236,7 @@ library
                 mtl        >= 2.0.1 && < 3,
                 deepseq    >= 1.1,
                 bytestring >= 0.9,
+                utf8-string         >= 1.0,
                 binary     >= 0.5,
                 hxt-charproperties  >= 9.1,
                 hxt-unicode         >= 9.0.1,

--- a/hxt/src/Text/XML/HXT/DOM/TypeDefs.hs
+++ b/hxt/src/Text/XML/HXT/DOM/TypeDefs.hs
@@ -210,11 +210,11 @@ instance Binary DTDElem where
 type Blob       = BS.ByteString
 
 blobToString    :: Blob -> String
-blobToString    = CS.unpack
+blobToString    = CS.unpack -- !!
 {-# INLINE blobToString #-}
 
 stringToBlob    :: String -> Blob
-stringToBlob    = CS.pack
+stringToBlob    = CS.pack -- !!
 {-# INLINE stringToBlob #-}
 
 -- -----------------------------------------------------------------------------

--- a/hxt/src/Text/XML/HXT/DOM/TypeDefs.hs
+++ b/hxt/src/Text/XML/HXT/DOM/TypeDefs.hs
@@ -32,7 +32,7 @@ import           Data.AssocList
 
 import           Data.Binary
 import qualified Data.ByteString.Lazy            as BS
-import qualified Data.ByteString.Lazy.Char8      as CS
+import qualified Data.ByteString.Lazy.UTF8       as LBSUTF8
 
 import           Data.Tree.NTree.TypeDefs
 import           Data.Tree.NTree.Zipper.TypeDefs
@@ -210,11 +210,11 @@ instance Binary DTDElem where
 type Blob       = BS.ByteString
 
 blobToString    :: Blob -> String
-blobToString    = CS.unpack -- !!
+blobToString    = LBSUTF8.toString
 {-# INLINE blobToString #-}
 
 stringToBlob    :: String -> Blob
-stringToBlob    = CS.pack -- !!
+stringToBlob    = LBSUTF8.fromString
 {-# INLINE stringToBlob #-}
 
 -- -----------------------------------------------------------------------------

--- a/hxt/src/Text/XML/HXT/DOM/TypeDefs.hs
+++ b/hxt/src/Text/XML/HXT/DOM/TypeDefs.hs
@@ -31,7 +31,9 @@ import           Control.FlatSeq
 import           Data.AssocList
 
 import           Data.Binary
+import qualified Data.ByteString                 as SBS
 import qualified Data.ByteString.Lazy            as BS
+import qualified Data.ByteString.Lazy.Char8      as CS
 import qualified Data.ByteString.Lazy.UTF8       as LBSUTF8
 
 import           Data.Tree.NTree.TypeDefs
@@ -210,7 +212,7 @@ instance Binary DTDElem where
 type Blob       = BS.ByteString
 
 blobToString    :: Blob -> String
-blobToString    = LBSUTF8.toString
+blobToString blb = if SBS.isValidUtf8 (BS.toStrict blb) then LBSUTF8.toString blb else CS.unpack blb
 {-# INLINE blobToString #-}
 
 stringToBlob    :: String -> Blob

--- a/hxt/test/ReadBinary.hs
+++ b/hxt/test/ReadBinary.hs
@@ -1,12 +1,15 @@
-module Main
-where
+module Main where
 
+import Data.ByteString.Lazy.UTF8 (fromString)
+import Data.Tree.NTree.TypeDefs
 import Text.XML.HXT.Core
+import qualified Text.XML.HXT.DOM.ShowXml
+import Text.XML.HXT.DOM.TypeDefs
 
 main :: IO ()
-main = runX
-       ( readBinaryValue "emil"
-         >>>
-         xshow this
-       ) >> return ()
-             
+main = do
+  let good = fromString "emăil"
+      bad = Text.XML.HXT.DOM.ShowXml.xshowBlob [NTree (XText "emăil") []]
+  if bad /= good
+    then error $ "ByteStrings don't match: " ++ show good ++ " /= " ++ show bad
+    else pure ()


### PR DESCRIPTION
hxt uses `Data.ByteString.Lazy.Char8.{pack,unpack}` for handling unicode strings.  this breaks on less common characters.

here's a test and the fix.

sorry about the sloppily baked-in test, wanted to get this published before end of business day :-)